### PR TITLE
Add youtube event fetching with a basic script

### DIFF
--- a/projects/1.2-committee-youtube/congress_youtube/youtube/fetch/main.py
+++ b/projects/1.2-committee-youtube/congress_youtube/youtube/fetch/main.py
@@ -1,25 +1,36 @@
-import polars as pl
 from pathlib import Path
+import csv
 from ...auth import load_youtube_api_key
 from .youtube_event_fetcher import YoutubeEventFetcher
 
 
+def get_committee_handle(committee: str, csv_path: Path) -> str:
+    with open(csv_path, newline="", encoding="utf-8") as csvfile:
+        reader = csv.DictReader(csvfile)
+        for row in reader:
+            if row["committee"] == committee:
+                return row["handle"]
+    raise ValueError(f"No handle found for committee: {committee}")
+
+
 def main():
-    committee, title = "Appropriations", "Budget Hearing – U.S. Department of Health and Human Services"
+    ## TODO: this is hard-coding a single committee name and title in
+    ##  to see if we can find it.
+    test_committee, test_title = (
+        "Appropriations",
+        "Budget Hearing - U.S. Department of Health and Human Services",
+    )
 
     api_key = load_youtube_api_key()
     fetcher = YoutubeEventFetcher(api_key)
 
-    youtube_accounts = pl.read_csv(Path(__file__).parent.parent / "youtube-accounts.csv")
-
-    appropriations_handle = youtube_accounts.filter(pl.col("Committee Name") == committee).row(0, named=True)["handle"]
-
-    appropriations_channel = fetcher.get_channel(appropriations_handle)
-
-    video = fetcher.get_event(
-        title=title,
-        channel_id=appropriations_channel["id"]
+    test_handle = get_committee_handle(
+        test_committee, Path(__file__).parent.parent / "youtube-accounts.csv"
     )
+    test_channel = fetcher.get_channel(test_handle)
+
+    video = fetcher.get_event(title=test_title, channel_id=test_channel["id"])
+
     print(video)
     print(f"Recording URL: https://youtu.be/{video['id']['videoId']}")
 

--- a/projects/1.2-committee-youtube/congress_youtube/youtube/fetch/main.py
+++ b/projects/1.2-committee-youtube/congress_youtube/youtube/fetch/main.py
@@ -1,10 +1,27 @@
+import polars as pl
+from pathlib import Path
 from ...auth import load_youtube_api_key
 from .youtube_event_fetcher import YoutubeEventFetcher
 
 
 def main():
-    fetcher = YoutubeEventFetcher()
+    committee, title = "Appropriations", "Budget Hearing – U.S. Department of Health and Human Services"
+
     api_key = load_youtube_api_key()
+    fetcher = YoutubeEventFetcher(api_key)
+
+    youtube_accounts = pl.read_csv(Path(__file__).parent.parent / "youtube-accounts.csv")
+
+    appropriations_handle = youtube_accounts.filter(pl.col("Committee Name") == committee).row(0, named=True)["handle"]
+
+    appropriations_channel = fetcher.get_channel(appropriations_handle)
+
+    video = fetcher.get_event(
+        title=title,
+        channel_id=appropriations_channel["id"]
+    )
+    print(video)
+    print(f"Recording URL: https://youtu.be/{video['id']['videoId']}")
 
 
 if __name__ == "__main__":

--- a/projects/1.2-committee-youtube/congress_youtube/youtube/fetch/youtube_event_fetcher.py
+++ b/projects/1.2-committee-youtube/congress_youtube/youtube/fetch/youtube_event_fetcher.py
@@ -1,3 +1,74 @@
-class YoutubeEventFetcher(object):
-    def __init__(self):
-        raise NotImplementedError("YouTube Fetcher is not implemented yet.")
+import logging
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+
+
+class YoutubeEventFetcher:
+    """
+    A utility class for retrieving YouTube video and channel data using the YouTube Data API.
+
+    Attributes:
+        youtube: The YouTube API service client.
+
+    Methods:
+        get_event(): Search for a YouTube video by title and optional channel ID.
+        get_channel(): Retrieve channel information by handle.
+    """
+
+    API_SERVICE_NAME = 'youtube'
+    API_VERSION = 'v3'
+
+    def __init__(self, youtube_api_key: str):
+        """
+        Initialize the YouTube API client with the provided API key.
+
+        Args:
+            youtube_api_key (str): The YouTube Data API key for authentication.
+        """
+        self.youtube = build(self.API_SERVICE_NAME, self.API_VERSION, developerKey=youtube_api_key)
+
+    def get_event(self, title: str, channel_id: str | None = None) -> dict | None:
+        """
+        Search for a YouTube video by title and optional channel ID.
+
+        Args:
+            title (str): The video title to search for.
+            channel_id (str, optional): The channel ID to limit the search to.
+
+        Returns:
+            dict | None: The first search result item, or None if an error occurs.
+        """
+
+        try:
+            search_response = self.youtube.search().list(
+                q=title,
+                part="snippet",
+                channelId=channel_id,
+                maxResults=1
+            ).execute()
+
+            return search_response["items"][0]
+        except (HttpError, IndexError) as ex:
+            logging.error(ex)
+            return None
+
+    def get_channel(self, handle: str) -> dict | None:
+        """
+        Retrieve channel information by handle.
+
+        Args:
+            handle (str): The YouTube channel handle (e.g., @HouseAppropriationsCommittee).
+
+        Returns:
+            dict | None: The channel information, or None if an error occurs.
+        """
+
+        try:
+            channel_response = self.youtube.channels().list(
+                part="snippet",
+                forHandle=handle
+            ).execute()
+
+            return channel_response["items"][0]
+        except (HttpError, IndexError) as ex:
+            logging.error(ex)

--- a/projects/1.2-committee-youtube/congress_youtube/youtube/fetch/youtube_event_fetcher.py
+++ b/projects/1.2-committee-youtube/congress_youtube/youtube/fetch/youtube_event_fetcher.py
@@ -15,8 +15,8 @@ class YoutubeEventFetcher:
         get_channel(): Retrieve channel information by handle.
     """
 
-    API_SERVICE_NAME = 'youtube'
-    API_VERSION = 'v3'
+    API_SERVICE_NAME = "youtube"
+    API_VERSION = "v3"
 
     def __init__(self, youtube_api_key: str):
         """
@@ -25,7 +25,9 @@ class YoutubeEventFetcher:
         Args:
             youtube_api_key (str): The YouTube Data API key for authentication.
         """
-        self.youtube = build(self.API_SERVICE_NAME, self.API_VERSION, developerKey=youtube_api_key)
+        self.youtube = build(
+            self.API_SERVICE_NAME, self.API_VERSION, developerKey=youtube_api_key
+        )
 
     def get_event(self, title: str, channel_id: str | None = None) -> dict | None:
         """
@@ -40,12 +42,11 @@ class YoutubeEventFetcher:
         """
 
         try:
-            search_response = self.youtube.search().list(
-                q=title,
-                part="snippet",
-                channelId=channel_id,
-                maxResults=1
-            ).execute()
+            search_response = (
+                self.youtube.search()
+                .list(q=title, part="snippet", channelId=channel_id, maxResults=1)
+                .execute()
+            )
 
             return search_response["items"][0]
         except (HttpError, IndexError) as ex:
@@ -64,10 +65,9 @@ class YoutubeEventFetcher:
         """
 
         try:
-            channel_response = self.youtube.channels().list(
-                part="snippet",
-                forHandle=handle
-            ).execute()
+            channel_response = (
+                self.youtube.channels().list(part="snippet", forHandle=handle).execute()
+            )
 
             return channel_response["items"][0]
         except (HttpError, IndexError) as ex:

--- a/projects/1.2-committee-youtube/congress_youtube/youtube/youtube-accounts.csv
+++ b/projects/1.2-committee-youtube/congress_youtube/youtube/youtube-accounts.csv
@@ -1,19 +1,19 @@
-Committee Name, href, secondary
-Agriculture, https://www.youtube.com/@AgRepublicans, https://www.youtube.com/@HouseAgDems
-Appropriations, https://www.youtube.com/@HouseAppropriationsCommittee, 
-Armed Services, https://www.youtube.com/@HouseArmedServices,
-Budget, https://www.youtube.com/@HouseBudgetGOP, https://www.youtube.com/@HouseBudgetDems
-Education & Workforce, https://www.youtube.com/@EdWorkforceCmte,
-Energy & Commerce, https://www.youtube.com/@energyandcommerce,
-Financial Services, https://www.youtube.com/@GOPFinancialServices, https://www.youtube.com/@USHouseFSC
-Foreign Affairs, https://www.youtube.com/@HouseForeignGOP, https://www.youtube.com/@houseforeign,
-Homeland Security, https://www.youtube.com/@HouseHomeland,
-House Administration, https://www.youtube.com/@CommitteeonHouseAdministration,
-Judiciary, https://www.youtube.com/@USHouseJudiciaryGOP, https://www.youtube.com/@JudiciaryDems
-Natural Resources, https://www.youtube.com/@NaturalResourcesGOP, https://www.youtube.com/@NaturalResourcesDems
-Oversight and Government Reform, https://www.youtube.com/@OversightandGovernmentReform,
-Rules, https://www.youtube.com/@HouseRulesCommittee,
-"Science, Space, and Technology", https://www.youtube.com/@housescience,
-Small Business, https://www.youtube.com/@HouseSmallBiz,
-Veterans' Affairs, https://www.youtube.com/@HouseVeteransAffairs,
-Ways and Means, https://www.youtube.com/@WaysandMeansCommittee,
+Committee Name,handle,secondary
+Agriculture,@AgRepublicans,@HouseAgDems
+Appropriations,@HouseAppropriationsCommittee,
+Armed Services,@HouseArmedServices,
+Budget,@HouseBudgetGOP,@HouseBudgetDems
+Education & Workforce,@EdWorkforceCmte,
+Energy & Commerce,@energyandcommerce,
+Financial Services,@USHouseFSC,@GOPFinancialServices
+Foreign Affairs,@houseforeign,@HouseForeignGOP
+Homeland Security,@HouseHomeland,
+House Administration,@CommitteeonHouseAdministration,
+Judiciary,@USHouseJudiciaryGOP,@JudiciaryDems
+Natural Resources,@NaturalResourcesGOP,@NaturalResourcesDems
+Oversight and Government Reform,@OversightandGovernmentReform,
+Rules,@HouseRulesCommittee,
+"Science, Space, and Technology",@housescience,
+Small Business,@HouseSmallBiz,
+Veterans' Affairs,@HouseVeteransAffairs,
+Ways and Means,@WaysandMeansCommittee,

--- a/projects/1.2-committee-youtube/congress_youtube/youtube/youtube-accounts.csv
+++ b/projects/1.2-committee-youtube/congress_youtube/youtube/youtube-accounts.csv
@@ -1,4 +1,4 @@
-Committee Name,handle,secondary
+committee,handle,secondary
 Agriculture,@AgRepublicans,@HouseAgDems
 Appropriations,@HouseAppropriationsCommittee,
 Armed Services,@HouseArmedServices,

--- a/projects/1.2-committee-youtube/pyproject.toml
+++ b/projects/1.2-committee-youtube/pyproject.toml
@@ -15,6 +15,8 @@ license = { text = "MIT" }
 dependencies = [
   "requests>=2.25.0",
   "lxml>=4.9.0",
+  "google-api-python-client>=2.179.0",
+  "polars>=1.8.2",
 ]
 
 [project.urls]

--- a/projects/1.2-committee-youtube/pyproject.toml
+++ b/projects/1.2-committee-youtube/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
   "requests>=2.25.0",
   "lxml>=4.9.0",
   "google-api-python-client>=2.179.0",
-  "polars>=1.8.2",
   "tinydb"
 ]
 


### PR DESCRIPTION
# Add youtube event fetching with a basic script
Resolves #3 

## Description
* Implement `YouTubeEventFetcher` with `get_event` and `get_channel` functions.
* `get_event` searches for the first YouTube video given a title and optional channel ID.
* `get_channel` returns channel information given the handle (`@HouseAppropriationsCommittee`)
* YouTube API client is initialized in constructor
* youtube-fetch script currently uses the `youtube-accounts.csv` and `YouTubeEventFetcher` to get information about a preset committee and video title. Currently only takes the primary channel for a committee into account when searching for recording videos. Does not output anything to file or database yet. 
* Converted committee channel URLs into handles in `youtube-accounts.csv` so that we don't have to parse the channel handle from the channel URL.

## Testing
```
$ uv run youtube-fetch --youtube-api-key <YOUTUBE_API_KEY>

{'kind': 'youtube#searchResult', 'etag': 'eFQ5sY5yrKhzKZoaldMoJPn0rnc', 'id': {'kind': 'youtube#video', 'videoId': 'jUcDvNfYQDU'}, 'snippet': {'publishedAt': '2025-05-14T16:03:10Z', 'channelId': 'UCMaSlF09S0fpoRshS2t_7XA', 'title': 'Budget Hearing – U.S. Department of Health and Human Services', 'description': 'House Committee on Appropriations, Subcommittee on Labor, Health and Human Services, Education, and Related Agencies ...', 'thumbnails': {'default': {'url': 'https://i.ytimg.com/vi/jUcDvNfYQDU/default.jpg', 'width': 120, 'height': 90}, 'medium': {'url': 'https://i.ytimg.com/vi/jUcDvNfYQDU/mqdefault.jpg', 'width': 320, 'height': 180}, 'high': {'url': 'https://i.ytimg.com/vi/jUcDvNfYQDU/hqdefault.jpg', 'width': 480, 'height': 360}}, 'channelTitle': 'House Appropriations Committee', 'liveBroadcastContent': 'none', 'publishTime': '2025-05-14T16:03:10Z'}}
Recording URL: https://youtu.be/jUcDvNfYQDU
```