### PR TITLE
docs: rewrite README from scratch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,166 +1,112 @@
-# congressional-tech
+# Congressional Tech
 
-## Contributors
-| Fork | Branch Name  | Description                   |
-|-----------------|--------------|-------------------------------|
-| [agurvich](https://github.com/agurvich/congressional-tech)        | feature/tinydb  | adding TinyDB support  |
-| mikewolfd        | N/A  | N/A  |
-| [ezrajohnmitchell](https://github.com/ezrajohnmitchell/congressional-tech)        | N/A  | N/A  |
-| dragonejt        | 3-congress_youtube-scrapes-congressional-committee-youtube-channels-for-all-videos  | Scraping YouTube metadata  |
-| [fwliu1](https://github.com/fwliu1/congressional-tech-youtube)        | N/A  | N/A  |
+**Open-source tools for a more transparent Congress.**
 
-## Git LFS Setup
+A [Civic Tech DC](https://civictechdc.org) initiative, in partnership with the American Governance Institute, building small, practical tools that make congressional data and operations easier to find, track, and understand — for congressional staff and the public alike. Every proposal here started as a real request from people working in and around Congress.
 
-⚠️ This repository uses [Git Large File Storage (LFS)](https://git-lfs.com/).️ ️⚠️
+🔗 **Live site: <https://civictechdc.github.io/congressional-tech/>** — browse the project catalog, read the proposals, and explore the committee YouTube coverage dashboard.
 
-You **must** install Git LFS before cloning or working with this repo.
+## What's in here
 
-### Install Git LFS
+This is a [Turborepo](https://turborepo.com) monorepo using npm workspaces, in two layers.
 
-**macOS (Homebrew):**
+### `apps/` — things you run or deploy
+
+| App | What it is |
+| --- | --- |
+| **`site`** | The public website (Astro). Project catalog, proposals, and interactive dashboards. Deployed to GitHub Pages. |
+| **`committee_youtube`** | CLI tools that scan congressional committee YouTube channels and flag videos missing the official Event ID that links them back to Congress.gov. |
+| **`inflation_gsheets`** | Pulls inflation data (BLS CPI + FRED alternative measures) into CSVs that feed a Google Sheets inflation calculator. |
+
+### `packages/` — shared Python libraries the apps build on
+
+| Package | What it provides |
+| --- | --- |
+| **`congress_shared`** | Auth, config, and reference data shared across the tools. |
+| **`congress_api`** | Fetch and analyze committee + event data from Congress.gov. CLIs: `congress-fetch`, `congress-analyze`. |
+| **`youtube_api`** | Fetch and analyze committee YouTube data. CLIs: `youtube-fetch`, `youtube-analyze`. |
+| **`committee_meeting`** | Committee meeting metadata helpers. |
+
+## The project catalog
+
+The work is grouped into five themes. The site renders 19 proposals (each with a problem and a proposed solution) plus the tools already shipped. The source of truth is plain markdown you can read right here on GitHub: **[`apps/site/src/content/`](apps/site/src/content)**.
+
+| # | Theme |
+| --- | --- |
+| I | Enhancing Congressional Data Accessibility & Usability |
+| II | Workflow Efficiency Tools for Congressional Operations |
+| III | Leveraging AI for Content Enhancement & Analysis |
+| IV | Predictive & Analytical Tools for Legislative Insight |
+| V | Basic Utility Tools |
+
+Two proposals are working tools today: the **Committee YouTube coverage dashboard** (I.2) and the **Google Sheets inflation calculator** (V.1).
+
+## Sub-projects
+
+Two sister tools built by [AgoraDMV](https://github.com/AgoraDMV), forked into this org and kept in sync with upstream daily:
+
+- **[DeltaTrack](https://github.com/civictechdc/DeltaTrack)** — structurally diffs U.S. bill versions from GPO govinfo (added / removed / modified / moved sections), with an account-level old→new money table for appropriations. Local and zero-dependency, built for Hill staffers.
+- **[BillTrax](https://github.com/civictechdc/BillTrax)** — a public legislative-intelligence platform: ingests Congress.gov data, structures bill text, tracks funding changes across versions, and adds AI summaries and topic tags.
+
+## Getting started
+
+**Prerequisites:** Node 20+, Python 3.12+, and [`uv`](https://docs.astral.sh/uv/) or `pip`.
+
+### The website
+
 ```bash
-brew install git-lfs
+cd apps/site
+npm install
+npm run dev      # serves http://localhost:4321/congressional-tech/
+npm run build    # static output in dist/
 ```
 
-Linux (Debian/Ubuntu):
+Content lives as markdown under `src/content/` (themes, proposals, projects) — add or edit a `.md` file and the site picks it up.
+
+### The Python tools
+
+One editable install pulls the whole package graph:
 
 ```bash
-sudo apt-get update
-sudo apt-get install git-lfs
+pip install -e apps/committee_youtube      # brings in congress_shared, youtube_api, congress_api
+# or: uv pip install -e apps/committee_youtube
 ```
 
-Linux (Fedora/RHEL/CentOS):
+The CLIs are then on your PATH:
 
 ```bash
-sudo dnf install git-lfs
+youtube-fetch --help       # needs YOUTUBE_DATA_API_KEY
+youtube-analyze --help
+congress-fetch --help      # needs a Congress.gov API key
+congress-analyze --help
 ```
 
-Windows:
-	•	Download and run the installer from https://git-lfs.com/
-	•	Or install via Chocolatey:
+Inflation data:
 
 ```bash
-choco install git-lfs
+# BLS CPI index grid -> src/data/historical-cpi.csv
+python apps/inflation_gsheets/src/fetch-cpi-convert-csv.py
+
+# BLS + FRED alternative measures (+ optional Adobe/PriceStats) as YoY% -> src/data/inflation-sources.csv
+python apps/inflation_gsheets/src/fetch-inflation-sources.py --aggregate
 ```
 
-### Initialize Git LFS
+### Dev container
 
-Run this once after installing:
+The repo ships a [dev container](https://containers.dev/) that installs the Python graph and Node dependencies for you. In VS Code, choose **Reopen in Container**.
 
-```bash
-git lfs install
-```
+## Automation
 
-⚠️ If you don’t install Git LFS then running `git clone` will result in the following error message:
-```bash
-git-lfs filter-process: git-lfs: command not found
-fatal: the remote end hung up unexpectedly
-warning: Clone succeeded, but checkout failed.
-You can inspect what was checked out with 'git status'
-and retry with 'git restore --source=HEAD :/'
-```
-in which case you must delete the directory, install Git LFS following the instructions above, and try again.
+| Workflow | Cadence | What it does |
+| --- | --- | --- |
+| `deploy-pages.yml` | on push to `main` | Builds `apps/site` and deploys it to GitHub Pages. |
+| `bls-cpi-update.yml` | monthly | Refreshes the CPI baseline and the multi-source inflation table. |
+| `update-youtube.yml` | weekly | Refreshes committee YouTube coverage data. |
 
-## Development Containers
+## Contributing
 
-🐳 This repository includes [Development Container](https://containers.dev/) configuration for a consistent development environment.
+Come build with us. Pick a proposal from the [catalog](https://civictechdc.github.io/congressional-tech/proposals/), open an issue, or say hello in the [Civic Tech DC](https://civictechdc.org) community. Newcomers welcome.
 
-### Quick Start with Devcontainers
+## License
 
-**Prerequisites:**
-- [Docker Desktop](https://www.docker.com/products/docker-desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
-- [VS Code](https://code.visualstudio.com/) with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
-
-**Getting Started:**
-1. Clone this repository (Git LFS will be automatically configured)
-2. Open the repository in VS Code
-3. When prompted, click **"Reopen in Container"** or press `Ctrl+Shift+P` and select **"Dev Containers: Reopen in Container"**
-4. Wait for the container to build and initialize (~3-5 minutes first time)
-
-**What's Included:**
-- **Ubuntu 22.04** base environment
-- **Python 3.11** with all project dependencies pre-installed
-- **Node.js 20** for the Next.js web application
-- **Git LFS** pre-configured and initialized
-- **VS Code extensions** for Python, TypeScript, and web development
-- **Helpful shell aliases** for quick navigation between projects
-
-**Available Commands:**
-```bash
-# Quick navigation
-ct-root      # Navigate to project root
-ct-app       # Navigate to Next.js app
-ct-youtube   # Navigate to YouTube data project
-ct-inflation # Navigate to inflation data project
-
-# YouTube data processing
-youtube-fetch --help      # Fetch committee YouTube videos  
-youtube-analyze --help    # Analyze videos for missing event IDs
-congress-fetch --help     # Fetch congressional meeting data
-
-# Web application
-cd app && npm run dev     # Start Next.js development server
-```
-
-**Benefits:**
-- ✅ **No local setup required** - everything works out of the box
-- ✅ **Consistent environment** - same setup for all developers and CI/CD
-- ✅ **Isolated dependencies** - won't interfere with your host system
-- ✅ **Pre-configured tools** - linting, formatting, and debugging ready to go
-
-### Development Environment Details
-
-For detailed development workflows, Git LFS data handling, and troubleshooting common issues, see the **[Development Container README](.devcontainer/README.md)**.
-
-Key development features:
-- Pre-configured Python and Node.js environments
-- Git LFS support with automatic data file handling
-- CLI commands for data processing and analysis
-- Comprehensive troubleshooting guidance
-
-## Project List
-
-The categorized project list is below. Detailed proposals and the interactive dashboard are built from the website app ([`apps/website`](https://github.com/civictechdc/congressional-tech/tree/main/apps/website)), with the underlying data in [`apps/website/src/data`](https://github.com/civictechdc/congressional-tech/tree/main/apps/website/src/data).
-
-| Project name |  Level of Effort
-|-----------------|--------------
-| **I. Enhancing Congressional Data Accessibility & Usability** |
-Unified Congressional Hearing & Markup Data Platform | 3
-[Congressional Committee YouTube Video Dashboard & Event ID Tracking](https://github.com/civictechdc/congressional-tech/tree/main/apps/committee_youtube) | 2
-Statements of Disbursements as Structured Data | 4
-Appropriations Data Pipeline & Historical Analysis | 5+
-||
-| **II. Workflow Efficiency Tools for Congressional Operations** |
-Automated Google Doc Creator for Meetings | 2
-GitHub Wiki Indexing Bookmarklet | 2
-Crosswalk Spreadsheet to Member Office Appropriations Submission Tool | 3
-Floor Schedule to iCal & Enhanced Congressional Schedule Aggregation | 1
-Congressional Job Board Aggregator | 1
-||
-| **III. Leveraging AI for Content Enhancement & Analysis** |
-CRS Report Accessibility & Integration | 3
-GAO Report Transformation & Dissemination | 3
-Automated Committee Hearing Transcripts & Summaries | 2.5
-Write My GovTrack Newsletter (AI-Powered Legislative Newsletter) | 5
-Witness Database with Proceeding Links & Testimony Summarization | 5
-||
-| **IV. Predictive & Analytical Tools for Legislative Insight** |
-Bills to Committee Referral Prediction | (not set)
-Bill Delay Tracker | (not set)
-Appropriations Notices & Deadlines Tracker | (not set)
-Committee Funding Tracker & Visualization | (not set)
-Line Up CBJs and Appropriations Committee Report Language | (not set)
-||
-| **V. Basic Utility Tools** |
-[Inflation Calculator for Google Sheets](https://github.com/civictechdc/congressional-tech/tree/main/apps/inflation_gsheets) | 1
-
-## Related repositories
-
-Standalone tools that are part of the congressional-tech initiative. Both were contributed by [AgoraDMV](https://github.com/AgoraDMV), forked into this org, and kept in sync with their upstreams daily via a GitHub Action (`.github/workflows/upstream-sync.yml` on each fork's `develop` branch).
-
-| Project | Repo (fork ← upstream) | What it does |
-|---|---|---|
-| **DeltaTrack** | [civictechdc/DeltaTrack](https://github.com/civictechdc/DeltaTrack) ← [AgoraDMV/DeltaTrack](https://github.com/AgoraDMV/DeltaTrack) | Structurally diffs U.S. bill versions pulled from GPO govinfo — surfaces added / removed / modified / moved sections instead of formatting noise, with an account-level old→new money table for appropriations. Zero-dependency and fully local; built for Hill staffers. [Live example (HR 4366)](https://agoradmv.github.io/DeltaTrack/hr4366_committee_vs_floor.html). |
-| **BillTrax** | [civictechdc/BillTrax](https://github.com/civictechdc/BillTrax) ← [AgoraDMV/BillTrax](https://github.com/AgoraDMV/BillTrax) | Public-facing legislative-intelligence platform: ingests Congress.gov data, parses bill text into structured sections, tracks funding changes across versions, and adds AI-generated summaries and topic tags for researchers, advocates, and planning teams. |
-
-DeltaTrack and BillTrax are deliberate sister projects: DeltaTrack is the local, zero-dependency diff engine for Hill staffers; BillTrax is the server-backed public platform layering AI, tracking, and cross-bill analysis on top of the same structured-bill approach.
+See [LICENSE](LICENSE).


### PR DESCRIPTION
Replaces the stale README (fork-branch table, obsolete Git LFS section, broken project links) with a useful one: what the repo is, the live site, the apps/packages layout, the project catalog + themes, sub-projects (DeltaTrack/BillTrax), real getting-started (site + Python CLIs + inflation data + devcontainer), and the automation workflows.