### PR TITLE
ci: make data-workflow pushes race-safe

### DIFF
--- a/.github/workflows/bls-cpi-update.yml
+++ b/.github/workflows/bls-cpi-update.yml
@@ -39,4 +39,10 @@ jobs:
           git add apps/inflation_gsheets/src/data/historical-cpi.csv
           git add apps/inflation_gsheets/src/data/inflation-sources.csv
           git commit -m "Auto-updated CPI + multi-source inflation CSVs" || echo "No changes"
-          git push
+          # Resilient push: another scheduled workflow may push to main
+          # between checkout and now (non-fast-forward). Rebase and retry.
+          for attempt in 1 2 3; do
+            git push && break
+            echo "push rejected (attempt $attempt) -- rebasing on origin/main"
+            git pull --rebase --autostash origin main
+          done

--- a/.github/workflows/update-youtube.yml
+++ b/.github/workflows/update-youtube.yml
@@ -59,4 +59,10 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add apps/committee_youtube/data/*
           git commit -m "Updated Events from YouTube" || echo "No changes"
-          git push
+          # Resilient push: another scheduled workflow may push to main
+          # between checkout and now (non-fast-forward). Rebase and retry.
+          for attempt in 1 2 3; do
+            git push && break
+            echo "push rejected (attempt $attempt) -- rebasing on origin/main"
+            git pull --rebase --autostash origin main
+          done


### PR DESCRIPTION
Both scheduled data workflows (`update-youtube`, `bls-cpi-update`) end their commit step with a bare `git push`. If the other one pushes to `main` first, the push is non-fast-forward and the run fails even though the tooling succeeded (exactly what happened when both were dispatched at once). This wraps the push in a rebase-and-retry loop so a concurrent push can't fail the run.