### PR TITLE
docs(site): link the inflation-calculator page to the (working) template

### DIFF
--- a/apps/site/src/content/projects/V.1.md
+++ b/apps/site/src/content/projects/V.1.md
@@ -11,6 +11,10 @@ A Google Sheets template for easily calculating inflation.
 
 A Google Sheets template plus supporting scripts for quickly adjusting
 dollar amounts for inflation — a small utility built for congressional
-staff and researchers.
+staff and researchers. Drop in an `=INFLATION(amount, start_year, end_year)`
+formula and the sheet auto-imports the latest BLS CPI data. A companion
+`InflationSources` tab compares BLS against the Fed's alternative measures
+(median, trimmed-mean, sticky-price), with an optional blended average.
 
+- **Template:** [Open in Google Sheets](https://docs.google.com/spreadsheets/d/1Rims_eUSdLdm5I2QTXc-3MoRaXmH2oFxHsvSNoDD-SQ/edit?usp=sharing) — File → Make a copy to use it
 - **Source:** [`apps/inflation_gsheets`](https://github.com/civictechdc/congressional-tech/tree/main/apps/inflation_gsheets)


### PR DESCRIPTION
The V.1 project page had no link to the actual Google Sheet — only to source code. Adds a **Template** link to the org-owned template (now imports live data), and notes the new `InflationSources` comparison tab. Merging redeploys the site.