### PR TITLE
Make DeltaTrack & BillTrax first-class sub-projects

### DIFF
--- a/apps/site/src/components/Footer.astro
+++ b/apps/site/src/components/Footer.astro
@@ -1,7 +1,14 @@
 ---
+import { getCollection } from 'astro:content';
 import { withBase } from '../lib/paths';
 
 const year = new Date().getFullYear();
+
+// Sub-project links come from the collection (single source of truth) and
+// point at each sub-project's own page rather than raw GitHub.
+const subprojects = (await getCollection('subprojects')).sort(
+  (a, b) => a.data.order - b.data.order,
+);
 
 const columns = [
   {
@@ -10,6 +17,7 @@ const columns = [
       { label: 'Project themes', href: withBase('/#themes') },
       { label: 'Proposals', href: withBase('/proposals/') },
       { label: 'Projects', href: withBase('/projects/') },
+      { label: 'Sub-projects', href: withBase('/subprojects/') },
       { label: 'YouTube coverage', href: withBase('/dashboard/') },
     ],
   },
@@ -30,8 +38,10 @@ const columns = [
   {
     heading: 'Sub-projects & partners',
     links: [
-      { label: 'DeltaTrack', href: 'https://github.com/civictechdc/DeltaTrack' },
-      { label: 'BillTrax', href: 'https://github.com/civictechdc/BillTrax' },
+      ...subprojects.map((sp) => ({
+        label: sp.data.title,
+        href: withBase(`/subprojects/${sp.data.id}/`),
+      })),
       { label: 'Civic Tech DC', href: 'https://www.civictechdc.org/' },
       {
         label: 'American Governance Institute',

--- a/apps/site/src/components/Header.astro
+++ b/apps/site/src/components/Header.astro
@@ -11,6 +11,7 @@ const links = [
   { key: 'home', label: 'Home', href: withBase('/') },
   { key: 'proposals', label: 'Proposals', href: withBase('/proposals/') },
   { key: 'projects', label: 'Projects', href: withBase('/projects/') },
+  { key: 'subprojects', label: 'Sub-projects', href: withBase('/subprojects/') },
   { key: 'dashboard', label: 'YouTube Coverage', href: withBase('/dashboard/') },
   { key: 'contribute', label: 'Contribute', href: withBase('/contribute/') },
 ];

--- a/apps/site/src/content/config.ts
+++ b/apps/site/src/content/config.ts
@@ -26,15 +26,6 @@ const proposals = defineCollection({
     status: z.enum(['idea', 'in-progress', 'built']),
     effort: z.string().optional(),
     repo: z.string().url().optional(),
-    related: z
-      .array(
-        z.object({
-          label: z.string(),
-          href: z.string().url(),
-          note: z.string(),
-        }),
-      )
-      .optional(),
   }),
 });
 
@@ -50,4 +41,26 @@ const projects = defineCollection({
   }),
 });
 
-export const collections = { themes, proposals, projects };
+/**
+ * Sub-projects: standalone repos (DeltaTrack, BillTrax) forked from AgoraDMV
+ * and maintained in the civictechdc org. First-class alongside proposals and
+ * projects — this collection is the single source of truth for their data.
+ */
+const subprojects = defineCollection({
+  loader: glob({ pattern: '*.md', base: './src/content/subprojects', generateId }),
+  schema: z.object({
+    id: z.string(),
+    title: z.string(),
+    tagline: z.string(),
+    repo: z.string().url(),
+    upstream: z.string().url(),
+    liveUrl: z.string().url().optional(),
+    liveLabel: z.string().optional(),
+    status: z.enum(['live', 'soft-launch', 'in-development']),
+    /** id of the proposal this sub-project advances (e.g. "I.4"). */
+    proposal: z.string(),
+    order: z.number().int(),
+  }),
+});
+
+export const collections = { themes, proposals, projects, subprojects };

--- a/apps/site/src/content/proposals/I.4.md
+++ b/apps/site/src/content/proposals/I.4.md
@@ -4,13 +4,6 @@ title: "Appropriations Data Pipeline & Historical Analysis"
 theme: "I"
 status: "in-progress"
 effort: "5+"
-related:
-  - label: "DeltaTrack"
-    href: "https://github.com/civictechdc/DeltaTrack"
-    note: "structural bill diffs + appropriations money table"
-  - label: "BillTrax"
-    href: "https://github.com/civictechdc/BillTrax"
-    note: "structured bill pipeline + funding-change tracking"
 ---
 
 Comprehensive pipeline to track appropriations in real time, extract line-item data, and analyze report language historically across House/Senate stages.

--- a/apps/site/src/content/subprojects/billtrax.md
+++ b/apps/site/src/content/subprojects/billtrax.md
@@ -1,0 +1,39 @@
+---
+id: "billtrax"
+title: "BillTrax"
+tagline: "Public legislative-intelligence platform"
+repo: "https://github.com/civictechdc/BillTrax"
+upstream: "https://github.com/AgoraDMV/BillTrax"
+liveUrl: "https://BillTrax.AgoraDMV.org"
+liveLabel: "Soft launch — BillTrax.AgoraDMV.org"
+status: "soft-launch"
+proposal: "I.4"
+order: 2
+---
+
+BillTrax is a public-facing legislative-intelligence platform that turns raw congressional data into structured, searchable, and summarized bill information for researchers, advocates, and planning teams.
+
+## What it does
+
+BillTrax ingests bill data from Congress.gov and builds an analysis layer on top of it:
+
+- **Congress.gov ingestion** of bills and their text across versions.
+- **Structured bill text**, parsed into sections rather than left as an opaque document.
+- **Funding-change tracking** that follows how dollar figures move between versions.
+- **AI-generated summaries and topic tags** that make each bill approachable for a non-specialist and searchable by subject.
+
+It is the server-backed, public counterpart to DeltaTrack: where DeltaTrack is a local, zero-dependency diff engine for Hill staffers, BillTrax is a hosted platform that layers AI, tracking, and cross-bill analysis on the same structured-bill approach. It is deploying to **BillTrax.AgoraDMV.org** as a soft launch.
+
+## Why it matters
+
+Legislative information is scattered across sources and slow to update, which keeps meaningful analysis out of reach for anyone without a dedicated research staff. BillTrax gives advocates, journalists, and planners a single place to read what a bill does, see how its funding changed, and track it over time.
+
+## How it relates to proposal I.4
+
+BillTrax advances proposal I.4, the Appropriations Data Pipeline & Historical Analysis. It builds the structured-data pipeline and funding-change tracking the proposal calls for, and exposes it publicly with AI-assisted summaries and topic tagging.
+
+## Links
+
+- [civictechdc fork](https://github.com/civictechdc/BillTrax) — the Congressional Tech copy, kept in sync with upstream daily.
+- [AgoraDMV upstream](https://github.com/AgoraDMV/BillTrax) — the original project this is forked from.
+- [Soft launch — BillTrax.AgoraDMV.org](https://BillTrax.AgoraDMV.org) — the public deployment target.

--- a/apps/site/src/content/subprojects/deltatrack.md
+++ b/apps/site/src/content/subprojects/deltatrack.md
@@ -1,0 +1,38 @@
+---
+id: "deltatrack"
+title: "DeltaTrack"
+tagline: "Structural bill-version diffs for Hill staffers"
+repo: "https://github.com/civictechdc/DeltaTrack"
+upstream: "https://github.com/AgoraDMV/DeltaTrack"
+liveUrl: "https://agoradmv.github.io/DeltaTrack/hr4366_committee_vs_floor.html"
+liveLabel: "Live example — HR 4366, committee vs. floor"
+status: "live"
+proposal: "I.4"
+order: 1
+---
+
+DeltaTrack structurally diffs two versions of a U.S. bill and shows what actually changed — added, removed, modified, and moved sections — instead of the formatting noise a plain text diff produces.
+
+## What it does
+
+DeltaTrack pulls official bill text straight from the GPO govinfo repository and compares two versions section by section. Rather than a line-by-line character diff, it reports the structural changes a legislative analyst cares about:
+
+- **Added, removed, and modified sections** between two stages of a bill.
+- **Moved sections**, detected and labeled as moves rather than a delete-plus-add.
+- An **account-level appropriations money table** that lays old dollar amounts against new ones, so a reader can see exactly how funding shifted.
+
+It runs fully local with **zero dependencies** — a single self-contained artifact a staffer can open in a browser, with nothing to install and no data leaving their machine.
+
+## Why it matters
+
+When an appropriations bill moves from subcommittee to full committee to the floor, the meaningful changes hide inside hundreds of pages of reformatted text. DeltaTrack answers "what changed, and by how much" in seconds — the exact question Hill staffers ask at every stage of markup.
+
+## How it relates to proposal I.4
+
+DeltaTrack is a concrete piece of proposal I.4, the Appropriations Data Pipeline & Historical Analysis. It delivers the report-language and bill-text comparison layer — identifying changes as measures move through the process and highlighting differences between versions — as a shipping, standalone tool.
+
+## Links
+
+- [civictechdc fork](https://github.com/civictechdc/DeltaTrack) — the Congressional Tech copy, kept in sync with upstream daily.
+- [AgoraDMV upstream](https://github.com/AgoraDMV/DeltaTrack) — the original project this is forked from.
+- [Live example — HR 4366, committee vs. floor](https://agoradmv.github.io/DeltaTrack/hr4366_committee_vs_floor.html) — a rendered diff you can open right now.

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -24,20 +24,16 @@ const inProgressCount = (themeId: string) =>
 const themeBlurb = (focus: string | null) =>
   focus ?? 'Small, immediately useful utilities for congressional work.';
 
-const subProjects = [
-  {
-    title: 'DeltaTrack',
-    href: 'https://github.com/civictechdc/DeltaTrack',
-    blurb:
-      'Structurally diffs U.S. bill versions from GPO govinfo — added, removed, and moved sections instead of formatting noise. Zero-dependency and fully local, built for Hill staffers.',
-  },
-  {
-    title: 'BillTrax',
-    href: 'https://github.com/civictechdc/BillTrax',
-    blurb:
-      'Public-facing legislative-intelligence platform: parses bill text into structured sections, tracks funding changes across versions, and layers on AI summaries and topic tags.',
-  },
-];
+const subprojects = (await getCollection('subprojects')).sort(
+  (a, b) => a.data.order - b.data.order,
+);
+
+const subStatusLabel = {
+  live: 'Live',
+  'soft-launch': 'Soft launch',
+  'in-development': 'In development',
+} as const;
+const summary = (body?: string) => body?.trim().split('\n')[0] ?? '';
 ---
 
 <Base title="Home" active="home">
@@ -106,14 +102,13 @@ const subProjects = [
     </div>
   </section>
 
-  <!-- Built projects + sub-projects strip -->
+  <!-- Built projects strip -->
   <section class="section section--tint">
     <div class="container">
       <h2 class="section-heading">Built and shipping</h2>
       <p class="section-intro">
-        Two proposals are working tools today, alongside DeltaTrack and
-        BillTrax — Congressional Tech sub-projects with their own repos, both
-        advancing the appropriations data pipeline proposal (I.4).
+        Two proposals are working tools today, with more in progress across the
+        five themes.
       </p>
       <div class="project-grid">
         {
@@ -135,15 +130,42 @@ const subProjects = [
             </article>
           ))
         }
+      </div>
+    </div>
+  </section>
+
+  <!-- Sub-projects: first-class alongside proposals and projects -->
+  <section class="section" id="subprojects">
+    <div class="container">
+      <div class="section-head">
+        <h2 class="section-heading">Sub-projects</h2>
+        <a class="slide-link" href={withBase('/subprojects/')}>
+          All sub-projects →
+        </a>
+      </div>
+      <p class="section-intro">
+        DeltaTrack and BillTrax are Congressional Tech sub-projects with their
+        own repositories, forked from AgoraDMV and kept in sync daily. Both
+        advance the appropriations data pipeline proposal, I.4.
+      </p>
+      <div class="project-grid">
         {
-          subProjects.map((repo) => (
+          subprojects.map((sp) => (
             <article class="card card--gold project-card">
-              <p class="eyebrow project-eyebrow">Sub-project</p>
-              <h3 class="card-title">{repo.title}</h3>
-              <p>{repo.blurb}</p>
+              <p class="eyebrow project-eyebrow">
+                Sub-project · {subStatusLabel[sp.data.status]}
+              </p>
+              <h3 class="card-title">{sp.data.title}</h3>
+              <p>{summary(sp.body)}</p>
               <div class="project-links">
-                <a class="slide-link" href={repo.href}>
-                  View on GitHub →
+                <a
+                  class="slide-link"
+                  href={withBase(`/subprojects/${sp.data.id}/`)}
+                >
+                  View sub-project →
+                </a>
+                <a class="slide-link" href={sp.data.repo}>
+                  Source on GitHub →
                 </a>
               </div>
             </article>
@@ -222,6 +244,19 @@ const subProjects = [
     color: var(--ctdc-ink-muted);
     max-width: 40rem;
     margin-bottom: var(--ctdc-space-lg);
+  }
+
+  /* Section heading with an inline "see all" link on the baseline */
+  .section-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--ctdc-space-2xs) var(--ctdc-space-md);
+  }
+
+  .section-head .slide-link {
+    font-size: var(--ctdc-text-sm);
   }
 
   .section--tint {

--- a/apps/site/src/pages/projects.astro
+++ b/apps/site/src/pages/projects.astro
@@ -13,26 +13,12 @@ const rendered = await Promise.all(
   })),
 );
 
-const subProjects = [
-  {
-    title: 'DeltaTrack',
-    href: 'https://github.com/civictechdc/DeltaTrack',
-    upstream: 'https://github.com/AgoraDMV/DeltaTrack',
-    blurb:
-      'Structurally diffs U.S. bill versions pulled from GPO govinfo — surfaces added, removed, modified, and moved sections instead of formatting noise, with an account-level old→new money table for appropriations. Zero-dependency and fully local; built for Hill staffers.',
-    example: {
-      label: 'Live example (HR 4366)',
-      href: 'https://agoradmv.github.io/DeltaTrack/hr4366_committee_vs_floor.html',
-    },
-  },
-  {
-    title: 'BillTrax',
-    href: 'https://github.com/civictechdc/BillTrax',
-    upstream: 'https://github.com/AgoraDMV/BillTrax',
-    blurb:
-      'Public-facing legislative-intelligence platform: ingests Congress.gov data, parses bill text into structured sections, tracks funding changes across versions, and adds AI-generated summaries and topic tags for researchers, advocates, and planning teams.',
-  },
-];
+// Sub-projects are first-class (own collection + pages); source them here so
+// there is no duplicated data. This page shows a pointer to their section.
+const subprojects = (await getCollection('subprojects')).sort(
+  (a, b) => a.data.order - b.data.order,
+);
+const summary = (body?: string) => body?.trim().split('\n')[0] ?? '';
 ---
 
 <Base
@@ -86,43 +72,61 @@ const subProjects = [
 
   <section class="section section--repos">
     <div class="container">
-      <h2 class="section-heading">Sub-projects</h2>
+      <div class="section-head">
+        <h2 class="section-heading">Sub-projects</h2>
+        <a class="slide-link" href={withBase('/subprojects/')}>
+          All sub-projects →
+        </a>
+      </div>
       <p class="section-intro">
         Congressional Tech sub-projects that live in their own repositories,
-        contributed by
+        forked from
         <a href="https://github.com/AgoraDMV">AgoraDMV</a> and kept in sync
         with their upstreams daily. They are deliberate complements:
         DeltaTrack is the local, zero-dependency diff engine for Hill
         staffers; BillTrax is the server-backed public platform layering AI,
         tracking, and cross-bill analysis on top of the same structured-bill
-        approach.
+        approach. Each has its own
+        <a href={withBase('/subprojects/')}>sub-project page</a>.
       </p>
       <div class="repo-grid">
         {
-          subProjects.map((repo) => (
+          subprojects.map((sp) => (
             <article class="card card--gold repo-card">
-              <h3 class="card-title">{repo.title}</h3>
-              <p class="repo-blurb">{repo.blurb}</p>
+              <h3 class="card-title">{sp.data.title}</h3>
+              <p class="repo-tagline">{sp.data.tagline}</p>
+              <p class="repo-blurb">{summary(sp.body)}</p>
               <ul class="repo-links">
                 <li>
-                  <a class="slide-link" href={withBase('/proposals/I.4/')}>
-                    Advances proposal I.4 →
+                  <a
+                    class="slide-link repo-detail"
+                    href={withBase(`/subprojects/${sp.data.id}/`)}
+                  >
+                    View sub-project →
                   </a>
                 </li>
                 <li>
-                  <a class="slide-link" href={repo.href}>
+                  <a
+                    class="slide-link"
+                    href={withBase(`/proposals/${sp.data.proposal}/`)}
+                  >
+                    Advances proposal {sp.data.proposal} →
+                  </a>
+                </li>
+                <li>
+                  <a class="slide-link" href={sp.data.repo}>
                     civictechdc fork →
                   </a>
                 </li>
                 <li>
-                  <a class="slide-link" href={repo.upstream}>
+                  <a class="slide-link" href={sp.data.upstream}>
                     AgoraDMV upstream →
                   </a>
                 </li>
-                {repo.example && (
+                {sp.data.liveUrl && (
                   <li>
-                    <a class="slide-link" href={repo.example.href}>
-                      {repo.example.label} →
+                    <a class="slide-link" href={sp.data.liveUrl}>
+                      {sp.data.liveLabel ?? 'View live'} →
                     </a>
                   </li>
                 )}
@@ -192,10 +196,33 @@ const subProjects = [
     border-top: 1px solid var(--ctdc-hairline-on-light);
   }
 
+  .section-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--ctdc-space-2xs) var(--ctdc-space-md);
+  }
+
+  .section-head .slide-link {
+    font-size: var(--ctdc-text-sm);
+  }
+
   .section-intro {
     color: var(--ctdc-ink-muted);
     max-width: 46rem;
     margin-bottom: var(--ctdc-space-lg);
+  }
+
+  .repo-tagline {
+    font-size: var(--ctdc-text-sm);
+    font-weight: var(--ctdc-weight-semibold);
+    color: var(--ctdc-ink);
+    margin-bottom: var(--ctdc-space-2xs);
+  }
+
+  .repo-detail {
+    color: var(--ctdc-primary);
   }
 
   .repo-grid {

--- a/apps/site/src/pages/proposals/[id].astro
+++ b/apps/site/src/pages/proposals/[id].astro
@@ -16,6 +16,11 @@ if (!proposal) throw new Error(`Unknown proposal: ${id}`);
 const theme = await getEntry('themes', proposal.data.theme);
 const { Content } = await render(proposal);
 
+// Sub-projects that advance this proposal (single source of truth).
+const relatedSubprojects = (await getCollection('subprojects'))
+  .filter((sp) => sp.data.proposal === proposal.data.id)
+  .sort((a, b) => a.data.order - b.data.order);
+
 const statusLabel = {
   built: 'Built',
   'in-progress': 'In progress',
@@ -61,7 +66,7 @@ const status = proposal.data.status;
         <Content />
       </article>
       {
-        proposal.data.related && (
+        relatedSubprojects.length > 0 && (
           <aside class="related-panel card card--gold" aria-label="Sub-project work">
             <h2 class="related-title">Sub-project work underway</h2>
             <p class="related-blurb">
@@ -69,12 +74,15 @@ const status = proposal.data.status;
               proposal:
             </p>
             <ul class="related-list">
-              {proposal.data.related.map((item) => (
+              {relatedSubprojects.map((sp) => (
                 <li>
-                  <a class="slide-link" href={item.href}>
-                    {item.label} →
+                  <a
+                    class="slide-link"
+                    href={withBase(`/subprojects/${sp.data.id}/`)}
+                  >
+                    {sp.data.title} →
                   </a>
-                  <span class="related-note">{item.note}</span>
+                  <span class="related-note">{sp.data.tagline}</span>
                 </li>
               ))}
             </ul>

--- a/apps/site/src/pages/subprojects/[id].astro
+++ b/apps/site/src/pages/subprojects/[id].astro
@@ -1,0 +1,187 @@
+---
+import { getCollection, getEntry, render } from 'astro:content';
+import Base from '../../layouts/Base.astro';
+import { withBase } from '../../lib/paths';
+
+export async function getStaticPaths() {
+  const subprojects = await getCollection('subprojects');
+  return subprojects.map((subproject) => ({
+    params: { id: subproject.data.id },
+  }));
+}
+
+const { id } = Astro.params;
+const subproject = await getEntry('subprojects', id);
+if (!subproject) throw new Error(`Unknown sub-project: ${id}`);
+const { Content } = await render(subproject);
+
+const proposal = await getEntry('proposals', subproject.data.proposal);
+
+const statusLabel = {
+  live: 'Live',
+  'soft-launch': 'Soft launch',
+  'in-development': 'In development',
+} as const;
+const statusBadge = {
+  live: 'built',
+  'soft-launch': 'in-progress',
+  'in-development': 'idea',
+} as const;
+const status = subproject.data.status;
+---
+
+<Base
+  title={subproject.data.title}
+  active="subprojects"
+  description={subproject.data.tagline}
+>
+  <section class="page-hero anchor-dark">
+    <div class="container">
+      <nav class="breadcrumb" aria-label="Breadcrumb">
+        <a class="breadcrumb-link" href={withBase('/subprojects/')}>
+          ← All sub-projects
+        </a>
+      </nav>
+      <p class="eyebrow page-eyebrow">Sub-project</p>
+      <h1 class="page-title">{subproject.data.title}</h1>
+      <p class="page-lead lead">{subproject.data.tagline}</p>
+      <div class="meta-row">
+        <span class={`badge badge--${statusBadge[status]}`}>
+          {statusLabel[status]}
+        </span>
+        {
+          proposal && (
+            <span class="meta-note">
+              Advances proposal {proposal.data.id}
+            </span>
+          )
+        }
+      </div>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="container">
+      <article class="prose">
+        <Content />
+      </article>
+
+      <div class="subproject-actions">
+        <a class="btn btn--primary" href={subproject.data.repo}>
+          Source on GitHub
+        </a>
+        {
+          subproject.data.liveUrl && (
+            <a class="btn btn--gold" href={subproject.data.liveUrl}>
+              {subproject.data.liveLabel ?? 'View live'}
+            </a>
+          )
+        }
+      </div>
+
+      {
+        proposal && (
+          <aside
+            class="related-panel card card--gold"
+            aria-label="Related proposal"
+          >
+            <h2 class="related-title">Part of proposal {proposal.data.id}</h2>
+            <p class="related-blurb">
+              {subproject.data.title} advances the {proposal.data.title}{' '}
+              proposal.
+            </p>
+            <a
+              class="slide-link"
+              href={withBase(`/proposals/${proposal.data.id}/`)}
+            >
+              Read proposal {proposal.data.id} →
+            </a>
+          </aside>
+        )
+      }
+    </div>
+  </section>
+</Base>
+
+<style>
+  .page-hero {
+    padding-block: var(--ctdc-space-2xl) var(--ctdc-space-3xl);
+  }
+
+  .breadcrumb {
+    margin-bottom: var(--ctdc-space-lg);
+  }
+
+  .breadcrumb-link {
+    display: inline-block;
+    font-size: var(--ctdc-text-sm);
+    font-weight: var(--ctdc-weight-semibold);
+    text-decoration: none;
+    transition:
+      transform var(--ctdc-duration-fast) var(--ctdc-ease),
+      color var(--ctdc-duration-fast) var(--ctdc-ease);
+  }
+
+  .breadcrumb-link:hover {
+    transform: translateX(-4px);
+  }
+
+  .page-eyebrow {
+    color: var(--ctdc-gold);
+    margin-bottom: var(--ctdc-space-2xs);
+  }
+
+  .page-title {
+    font-size: var(--ctdc-text-3xl);
+    max-width: 46rem;
+    margin-bottom: var(--ctdc-space-xs);
+  }
+
+  .page-lead {
+    color: var(--ctdc-on-dark);
+    max-width: 44rem;
+    margin-bottom: var(--ctdc-space-sm);
+  }
+
+  .meta-row {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--ctdc-space-2xs) var(--ctdc-space-sm);
+  }
+
+  .meta-note {
+    font-family: var(--ctdc-font-mono);
+    font-size: var(--ctdc-text-xs);
+    color: var(--ctdc-on-dark-caption);
+  }
+
+  .subproject-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--ctdc-space-sm);
+    margin-top: var(--ctdc-space-xl);
+  }
+
+  .related-panel {
+    margin-top: var(--ctdc-space-xl);
+    max-width: 46rem;
+  }
+
+  .related-panel:hover {
+    transform: none;
+    box-shadow: var(--ctdc-shadow-card);
+  }
+
+  .related-title {
+    font-size: var(--ctdc-text-lg);
+    color: var(--ctdc-primary);
+    margin-bottom: var(--ctdc-space-2xs);
+  }
+
+  .related-blurb {
+    font-size: var(--ctdc-text-sm);
+    color: var(--ctdc-ink-muted);
+    margin-bottom: var(--ctdc-space-sm);
+  }
+</style>

--- a/apps/site/src/pages/subprojects/index.astro
+++ b/apps/site/src/pages/subprojects/index.astro
@@ -1,0 +1,153 @@
+---
+import { getCollection } from 'astro:content';
+import Base from '../../layouts/Base.astro';
+import { withBase } from '../../lib/paths';
+
+const subprojects = (await getCollection('subprojects')).sort(
+  (a, b) => a.data.order - b.data.order,
+);
+
+const statusLabel = {
+  live: 'Live',
+  'soft-launch': 'Soft launch',
+  'in-development': 'In development',
+} as const;
+const statusBadge = {
+  live: 'built',
+  'soft-launch': 'in-progress',
+  'in-development': 'idea',
+} as const;
+
+const summary = (body?: string) => body?.trim().split('\n')[0] ?? '';
+---
+
+<Base
+  title="Sub-projects"
+  active="subprojects"
+  description="DeltaTrack and BillTrax — Congressional Tech sub-projects maintained in their own repositories, both advancing proposal I.4."
+>
+  <section class="page-hero anchor-dark">
+    <div class="container">
+      <p class="eyebrow page-eyebrow">Standalone repos</p>
+      <h1 class="page-title">Sub-projects</h1>
+      <p class="page-lead lead">
+        Congressional Tech sub-projects that live in their own repositories,
+        forked from <a href="https://github.com/AgoraDMV">AgoraDMV</a> into the
+        civictechdc org and kept in sync with their upstreams daily. They are
+        deliberate complements: DeltaTrack is the local, zero-dependency diff
+        engine for Hill staffers; BillTrax is the server-backed public platform
+        layering AI, tracking, and cross-bill analysis on the same
+        structured-bill approach. Both advance the appropriations data pipeline
+        proposal, I.4.
+      </p>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="container">
+      <div class="subproject-grid">
+        {
+          subprojects.map((sp) => (
+            <article class="card card--gold subproject-card">
+              <div class="subproject-meta">
+                <span class={`badge badge--${statusBadge[sp.data.status]}`}>
+                  {statusLabel[sp.data.status]}
+                </span>
+              </div>
+              <h2 class="card-title">{sp.data.title}</h2>
+              <p class="subproject-tagline">{sp.data.tagline}</p>
+              <p class="subproject-blurb">{summary(sp.body)}</p>
+              <div class="subproject-links">
+                <a
+                  class="slide-link subproject-detail"
+                  href={withBase(`/subprojects/${sp.data.id}/`)}
+                >
+                  View sub-project →
+                </a>
+                <a class="slide-link" href={withBase(`/proposals/${sp.data.proposal}/`)}>
+                  Advances proposal {sp.data.proposal} →
+                </a>
+                <a class="slide-link" href={sp.data.repo}>
+                  civictechdc fork →
+                </a>
+                <a class="slide-link" href={sp.data.upstream}>
+                  AgoraDMV upstream →
+                </a>
+                {sp.data.liveUrl && (
+                  <a class="slide-link" href={sp.data.liveUrl}>
+                    {sp.data.liveLabel ?? 'View live'} →
+                  </a>
+                )}
+              </div>
+            </article>
+          ))
+        }
+      </div>
+    </div>
+  </section>
+</Base>
+
+<style>
+  .page-hero {
+    padding-block: var(--ctdc-space-3xl);
+  }
+
+  .page-eyebrow {
+    color: var(--ctdc-gold);
+    margin-bottom: var(--ctdc-space-2xs);
+  }
+
+  .page-title {
+    font-size: var(--ctdc-text-3xl);
+    margin-bottom: var(--ctdc-space-xs);
+  }
+
+  .page-lead {
+    color: var(--ctdc-on-dark);
+    max-width: 48rem;
+    margin: 0;
+  }
+
+  .subproject-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
+    gap: var(--ctdc-space-md);
+  }
+
+  .subproject-card {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .subproject-meta {
+    margin-bottom: var(--ctdc-space-2xs);
+  }
+
+  .subproject-tagline {
+    font-size: var(--ctdc-text-sm);
+    font-weight: var(--ctdc-weight-semibold);
+    color: var(--ctdc-ink);
+    margin-bottom: var(--ctdc-space-2xs);
+  }
+
+  .subproject-blurb {
+    font-size: var(--ctdc-text-sm);
+    color: var(--ctdc-ink-muted);
+    flex-grow: 1;
+  }
+
+  .subproject-links {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: var(--ctdc-space-3xs);
+  }
+
+  .subproject-links .slide-link {
+    font-size: var(--ctdc-text-sm);
+  }
+
+  .subproject-detail {
+    color: var(--ctdc-primary);
+  }
+</style>


### PR DESCRIPTION
## What & why

DeltaTrack and BillTrax were hardcoded arrays **duplicated** across `index.astro` and `projects.astro`, with raw-GitHub links in the footer and a mention on the I.4 proposal. They had no pages and weren't in the nav — they read as afterthoughts. This makes them first-class, matching how proposals and projects are handled, using only the existing "Civic Premium Dark" design system (no new visual language).

## New content type + schema

New `subprojects` content collection (`src/content/subprojects/{deltatrack,billtrax}.md`) with a zod schema in `content/config.ts`:

`id, title, tagline, repo (url), upstream (url), liveUrl? (url), liveLabel?, status ('live' | 'soft-launch' | 'in-development'), proposal (id of the proposal it advances), order`

Each body is a real description (what it does, why it matters, how it relates to I.4) plus an external links list (civictechdc fork, AgoraDMV upstream, live demo/soft-launch target). The collection is the single source of truth.

## Routes added

- `/subprojects/` — index page listing both as gold-thread cards
- `/subprojects/deltatrack/` and `/subprojects/billtrax/` — detail pages (`src/pages/subprojects/[id].astro`), parity with the proposal/project detail pattern: breadcrumb, status badge, tagline, rendered markdown, source/live buttons, and a "Part of proposal I.4" panel linking back to I.4.

## Nav

Added `Sub-projects` (key `subprojects`, `/subprojects/`) to the `links` array in `Header.astro`; the new pages set `active="subprojects"`, so the item is reachable and marked active site-wide.

## De-duplication (single source of truth)

- Removed the hardcoded `subProjects` array from `index.astro`.
- Removed the hardcoded `subProjects` array from `projects.astro`.
- Removed the `related` array from proposal `I.4.md` (it existed only to describe these sub-projects) and dropped the now-unused `related` field from the proposals schema.
- I.4's "Sub-project work underway" panel is now derived from the collection (subprojects whose `proposal` === `I.4`), linking to the detail pages. I.4 linkage stays bidirectional and data-driven.
- Home, projects, and footer all source sub-project data from the collection now. Footer sub-project links point at the detail pages instead of raw GitHub.

## Verification

- `npm install && npm run build` succeeds — 27 pages, including the three new routes (`/subprojects/`, `/subprojects/deltatrack/`, `/subprojects/billtrax/`).
- `astro check`: 0 errors, 0 warnings, 0 hints.
- `grep -rn 'DeltaTrack\|BillTrax' apps/site/src`: remaining hits are the two collection `.md` files plus descriptive prose/`description` copy and one code comment — **no duplicated data arrays**.
- Active nav confirmed (`is-active` + `aria-current="page"`) on the index and both detail pages.
- Bidirectional I.4 links confirmed in `dist/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MczmfJHBipV8fkHs96gZNW