### PR TITLE
docs(site): generalize sub-projects framing (not all are AgoraDMV forks)

### DIFF
--- a/apps/site/src/content/config.ts
+++ b/apps/site/src/content/config.ts
@@ -42,8 +42,9 @@ const projects = defineCollection({
 });
 
 /**
- * Sub-projects: standalone repos (DeltaTrack, BillTrax) forked from AgoraDMV
- * and maintained in the civictechdc org. First-class alongside proposals and
+ * Sub-projects: Congressional Tech tools in their own repositories instead of
+ * this monorepo. Some are forks kept in sync with an upstream (e.g. DeltaTrack,
+ * BillTrax from AgoraDMV); others are built here. First-class alongside proposals and
  * projects — this collection is the single source of truth for their data.
  */
 const subprojects = defineCollection({
@@ -53,7 +54,7 @@ const subprojects = defineCollection({
     title: z.string(),
     tagline: z.string(),
     repo: z.string().url(),
-    upstream: z.string().url(),
+    upstream: z.string().url().optional(),
     liveUrl: z.string().url().optional(),
     liveLabel: z.string().optional(),
     status: z.enum(['live', 'soft-launch', 'in-development']),

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -145,7 +145,7 @@ const summary = (body?: string) => body?.trim().split('\n')[0] ?? '';
       </div>
       <p class="section-intro">
         DeltaTrack and BillTrax are Congressional Tech sub-projects with their
-        own repositories, forked from AgoraDMV and kept in sync daily. Both
+        own repositories, kept in sync with their upstreams daily. Both
         advance the appropriations data pipeline proposal, I.4.
       </p>
       <div class="project-grid">

--- a/apps/site/src/pages/projects.astro
+++ b/apps/site/src/pages/projects.astro
@@ -79,10 +79,9 @@ const summary = (body?: string) => body?.trim().split('\n')[0] ?? '';
         </a>
       </div>
       <p class="section-intro">
-        Congressional Tech sub-projects that live in their own repositories,
-        forked from
-        <a href="https://github.com/AgoraDMV">AgoraDMV</a> and kept in sync
-        with their upstreams daily. They are deliberate complements:
+        Congressional Tech tools that live in their own repositories instead of
+        this monorepo — some are forks kept in sync with an upstream daily,
+        others built here directly. The two so far are deliberate complements:
         DeltaTrack is the local, zero-dependency diff engine for Hill
         staffers; BillTrax is the server-backed public platform layering AI,
         tracking, and cross-bill analysis on top of the same structured-bill
@@ -118,11 +117,13 @@ const summary = (body?: string) => body?.trim().split('\n')[0] ?? '';
                     civictechdc fork →
                   </a>
                 </li>
-                <li>
-                  <a class="slide-link" href={sp.data.upstream}>
-                    AgoraDMV upstream →
-                  </a>
-                </li>
+                {sp.data.upstream && (
+                  <li>
+                    <a class="slide-link" href={sp.data.upstream}>
+                      {new URL(sp.data.upstream).pathname.split('/').filter(Boolean)[0]} upstream →
+                    </a>
+                  </li>
+                )}
                 {sp.data.liveUrl && (
                   <li>
                     <a class="slide-link" href={sp.data.liveUrl}>

--- a/apps/site/src/pages/subprojects/index.astro
+++ b/apps/site/src/pages/subprojects/index.astro
@@ -31,10 +31,10 @@ const summary = (body?: string) => body?.trim().split('\n')[0] ?? '';
       <p class="eyebrow page-eyebrow">Standalone repos</p>
       <h1 class="page-title">Sub-projects</h1>
       <p class="page-lead lead">
-        Congressional Tech sub-projects that live in their own repositories,
-        forked from <a href="https://github.com/AgoraDMV">AgoraDMV</a> into the
-        civictechdc org and kept in sync with their upstreams daily. They are
-        deliberate complements: DeltaTrack is the local, zero-dependency diff
+        Congressional Tech tools that live in their own repositories instead of
+        this monorepo — some are forks kept in sync with an upstream daily,
+        others are built here directly. The two so far are deliberate
+        complements: DeltaTrack is the local, zero-dependency diff
         engine for Hill staffers; BillTrax is the server-backed public platform
         layering AI, tracking, and cross-bill analysis on the same
         structured-bill approach. Both advance the appropriations data pipeline
@@ -70,9 +70,11 @@ const summary = (body?: string) => body?.trim().split('\n')[0] ?? '';
                 <a class="slide-link" href={sp.data.repo}>
                   civictechdc fork →
                 </a>
-                <a class="slide-link" href={sp.data.upstream}>
-                  AgoraDMV upstream →
-                </a>
+                {sp.data.upstream && (
+                  <a class="slide-link" href={sp.data.upstream}>
+                    {new URL(sp.data.upstream).pathname.split('/').filter(Boolean)[0]} upstream →
+                  </a>
+                )}
                 {sp.data.liveUrl && (
                   <a class="slide-link" href={sp.data.liveUrl}>
                     {sp.data.liveLabel ?? 'View live'} →


### PR DESCRIPTION
Sub-projects were framed as 'forked from AgoraDMV' at the category level. Fixes: generic definition (some are forks kept in sync with an upstream, others built here), `upstream` made optional in the schema, and the upstream link label is now derived from the URL (no hardcoded 'AgoraDMV'). Per-project detail for DeltaTrack/BillTrax unchanged.