### PR TITLE
feat: add congress_meeting_map as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "submodules/congress_meeting_map"]
+	path = submodules/congress_meeting_map
+	url = https://github.com/civictechdc/congress_meeting_map

--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ This is a [Turborepo](https://turborepo.com) monorepo using npm workspaces, in t
 | **`youtube_api`** | Fetch and analyze committee YouTube data. CLIs: `youtube-fetch`, `youtube-analyze`. |
 | **`committee_meeting`** | Committee meeting metadata helpers. |
 
+## Submodules
+
+Some org-native tools are vendored in as git submodules rather than living in the monorepo directly:
+
+| Submodule | What it is |
+| --- | --- |
+| **`submodules/congress_meeting_map`** | Maps congressional committee discussions into an explorable, interactive knowledge graph. |
+
+Clone the repo with its submodules — `git clone --recurse-submodules <url>` — or, in an existing checkout, run `git submodule update --init --recursive`.
+
 ## The project catalog
 
 The work is grouped into five themes. The site renders 19 proposals (each with a problem and a proposed solution) plus the tools already shipped. The source of truth is plain markdown you can read right here on GitHub: **[`apps/site/src/content/`](apps/site/src/content)**.


### PR DESCRIPTION
Adds the org's committee-discussion mapping tool (`congress_meeting_map`) as a git submodule at `submodules/congress_meeting_map` — org-native, so a submodule rather than a linked sub-project. Placed outside `apps/`/`packages/` to avoid the npm-workspace globs. Clone with `git clone --recurse-submodules` (or `git submodule update --init`). Not merged — confirm the path.￼