### PR TITLE
perf(site): fix hero/header scroll jank (remove backdrop-filter blur)

### DIFF
--- a/apps/site/src/components/Header.astro
+++ b/apps/site/src/components/Header.astro
@@ -64,14 +64,14 @@ const links = [
 </header>
 
 <style>
-  /* Dark glass anchor: midnight backing + blur + hairline bottom border */
+  /* Dark anchor: near-solid midnight backing + hairline bottom border.
+     No backdrop-filter — blur on a sticky header re-samples the backdrop on
+     every scroll frame and janks scrolling. */
   .site-header {
     position: sticky;
     top: 0;
     z-index: 50;
-    background: rgba(11, 26, 48, 0.88);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
+    background: rgba(11, 26, 48, 0.95);
     border-bottom: 1px solid var(--ctdc-hairline-on-dark);
   }
 

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -208,6 +208,9 @@ const summary = (body?: string) => body?.trim().split('\n')[0] ?? '';
     bottom: calc(-1 * var(--ctdc-space-xl));
     width: min(46rem, 62%);
     pointer-events: none;
+    /* Own compositor layer so the static SVG just translates on scroll
+       instead of repainting. */
+    transform: translateZ(0);
   }
 
   .hero-content {

--- a/apps/site/src/styles/global.css
+++ b/apps/site/src/styles/global.css
@@ -320,10 +320,11 @@ a:hover {
   color: var(--ctdc-gold);
 }
 
+/* Semi-opaque dark panel. Was a frosted backdrop-filter blur, but that
+   re-samples the hero SVG behind it every scroll frame and janks scrolling;
+   a solid-ish backing reads the same over the art and keeps text readable. */
 .glass-panel {
-  background: var(--ctdc-glass);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
+  background: rgba(9, 20, 38, 0.72);
   border: 1px solid var(--ctdc-hairline-on-dark);
   border-radius: var(--ctdc-radius-lg);
 }


### PR DESCRIPTION
The sticky header and the hero glass panel both used `backdrop-filter: blur(12px)`, which re-samples the backdrop every scroll frame — the sticky header does it continuously across the whole page, and the hero panel does it over the detailed Capitol SVG. That's the scroll lag. Replaced both with slightly more opaque solid backgrounds (near-identical look, header was already 88% opaque) and promoted the SVG to its own compositor layer. Verified the home still reads clean.