### PR TITLE
feat(site): add nav link back to civictechdc.org

### DIFF
--- a/apps/site/src/components/Header.astro
+++ b/apps/site/src/components/Header.astro
@@ -39,6 +39,11 @@ const links = [
           ))
         }
         <li>
+          <a class="nav-link" href="https://www.civictechdc.org">
+            civictechdc.org
+          </a>
+        </li>
+        <li>
           <a
             class="nav-link nav-link--github"
             href="https://github.com/civictechdc/congressional-tech"


### PR DESCRIPTION
Adds an external nav link to the main Civic Tech DC site (`www.civictechdc.org`), placed alongside the GitHub link, so visitors can get back to the parent org site.